### PR TITLE
Enabled power loss recovery

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1145,9 +1145,9 @@
    * an option on the LCD screen to continue the print from the last-known
    * point in the file.
    */
-  //#define POWER_LOSS_RECOVERY
+  #define POWER_LOSS_RECOVERY
   #if ENABLED(POWER_LOSS_RECOVERY)
-    #define PLR_ENABLED_DEFAULT   false // Power Loss Recovery enabled by default. (Set with 'M413 Sn' & M500)
+    #define PLR_ENABLED_DEFAULT   true // Power Loss Recovery enabled by default. (Set with 'M413 Sn' & M500)
     //#define BACKUP_POWER_SUPPLY       // Backup power / UPS to move the steppers on power loss
     //#define POWER_LOSS_ZRAISE       2 // (mm) Z axis raise on resume (on power loss with UPS)
     //#define POWER_LOSS_PIN         44 // Pin to detect power loss. Set to -1 to disable default pin on boards without module.


### PR DESCRIPTION
### Requirements

Compile in Arduino and flash the printer board with the new firmware.

### Description

This enables Power Loss Recovery in Marlin 2.0.6. This will create a file on the SD card and modify it at every layer. If this file exists on boot of the printer, the LCD screen should display a "would you like to continue where you left off?" type message.

### Benefits

Allows a print to continue even if a power failure occured during printing.

### Related Issues

This fulfills a feature request for allowing a print to resume after a power failure.
