### PR TITLE
Initial BLTouch Configuration

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -905,7 +905,7 @@
 /**
  * The BLTouch probe uses a Hall effect sensor and emulates a servo.
  */
-//#define BLTOUCH
+#define BLTOUCH
 
 /**
  * Pressure sensor with a BLTouch-like interface
@@ -982,6 +982,7 @@
  *
  * Specify a Probe position as { X, Y, Z }
  */
+// MIGHT NEED TO CHANGE BASED ON BLTOUCH MOUNT!
 #define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
 
 // Most probes should stay away from the edges of the bed, but
@@ -1229,7 +1230,7 @@
  */
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-//#define AUTO_BED_LEVELING_BILINEAR
+#define AUTO_BED_LEVELING_BILINEAR
 //#define AUTO_BED_LEVELING_UBL
 //#define MESH_BED_LEVELING
 
@@ -1237,14 +1238,14 @@
  * Normally G28 leaves leveling disabled on completion. Enable
  * this option to have G28 restore the prior leveling state.
  */
-//#define RESTORE_LEVELING_AFTER_G28
+#define RESTORE_LEVELING_AFTER_G28
 
 /**
  * Enable detailed logging of G28, G29, M48, etc.
  * Turn on with the command 'M111 S32'.
  * NOTE: Requires a lot of PROGMEM!
  */
-//#define DEBUG_LEVELING_FEATURE
+#define DEBUG_LEVELING_FEATURE
 
 #if ANY(MESH_BED_LEVELING, AUTO_BED_LEVELING_BILINEAR, AUTO_BED_LEVELING_UBL)
   // Gradually reduce leveling correction until a set height is reached,
@@ -1276,7 +1277,7 @@
 #if EITHER(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
 
   // Set the number of grid points per dimension.
-  #define GRID_MAX_POINTS_X 3
+  #define GRID_MAX_POINTS_X 4
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 
   // Probe along the Y axis, advancing X after each column
@@ -1380,7 +1381,7 @@
 // - Move the Z probe (or nozzle) to a defined XY point before Z Homing.
 // - Prevent Z homing when the Z probe is outside bed area.
 //
-//#define Z_SAFE_HOMING
+#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT X_CENTER  // X point for Z homing
@@ -1466,7 +1467,7 @@
  *   M501 - Read settings from EEPROM. (i.e., Throw away unsaved changes)
  *   M502 - Revert settings to "factory" defaults. (Follow with M500 to init the EEPROM.)
  */
-//#define EEPROM_SETTINGS     // Persistent storage with M500 and M501
+#define EEPROM_SETTINGS     // Persistent storage with M500 and M501
 //#define DISABLE_M503        // Saves ~2700 bytes of PROGMEM. Disable for release!
 #define EEPROM_CHITCHAT       // Give feedback on EEPROM commands. Disable to save PROGMEM.
 #define EEPROM_BOOT_SILENT    // Keep M503 quiet and only give errors during first load

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -982,8 +982,7 @@
  *
  * Specify a Probe position as { X, Y, Z }
  */
-// MIGHT NEED TO CHANGE BASED ON BLTOUCH MOUNT!
-#define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { -44, -3.736, 2.8 }
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.


### PR DESCRIPTION
### Requirements

Compile the firmware in Arduino and upload to the printer.

**First Time Setup**
Do the following sequence over the Arduino serial terminal:

```
M851 Z0.00 ;set z offset to 0
M500 ;save
M501 ;load

G28 ;home
G90 ;use absolute mode
M211 S0 ;disable software endstops
G1 Z0 ;z on real 0

; now put in ur paper and lower z till it rubs the paper
; !!!this is absolute, not relative now - so do small steps!!!
G1 Z-0.25 ;absolute -0.25mm from 0
G1 Z-1.00 ;absolute -1mm from 0
and so on (eg. I settled at -3.00, but it could be a little lower)

; save the z offset
M851 Z-3.00 ;set ur z-offset to around -3.00 or a little lower
M211 S1 ;enable software endstops again
M500 ;save
M501 ;load
G28 ;home
```

Put G29 in ur gcode startcode after G28


**Normal Operation**
2. Open serial terminal
3. Send G28 ; can have this in start gcode instead
4. Send G29 ; can have this in start gcode instead
5. Print test

### Description

This will enable auto-bed leveling with BL-Touch using the G29 gcode command.

### Benefits

This will automate the more difficult part of refining bed leveling.

### Related Issues

This fulfills a feature request of enabling use of BLTouch auto bed leveling for the printer.
